### PR TITLE
Removed basic auth base64 encoding options

### DIFF
--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -261,7 +261,7 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
     class public func basicAuth(username: String, password: String) -> String {
         let authString = "\(username):\(password)"
         let authData = authString.dataUsingEncoding(NSUTF8StringEncoding)
-        let base64String = authData!.base64EncodedStringWithOptions(NSDataBase64EncodingOptions.Encoding76CharacterLineLength)
+        let base64String = authData!.base64EncodedStringWithOptions(nil)
 
         return "Basic \(base64String)"
     }


### PR DESCRIPTION
The [`NSDataBase64Encoding76CharacterLineLength`](https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundation/Classes/NSData_Class/index.html#//apple_ref/c/econst/NSDataBase64Encoding76CharacterLineLength) option...

> set[s] the maximum line length to 76 characters, after which a line ending is inserted

...thus adding a line ending to my HTTP header, resulting the header not being sent at all.
