### PR TITLE
Fixed Issue #18 - Not buffering data between didReceiveData callbacks

### DIFF
--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -30,7 +30,8 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
     internal var task : NSURLSessionDataTask?
     private var operationQueue: NSOperationQueue
     private var errorBeforeSetErrorCallBack: NSError?
-
+    internal let receivedDataBuffer: NSMutableData
+    
     var event = Dictionary<String, String>()
 
     
@@ -41,6 +42,7 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
         self.readyState = EventSourceState.Closed
         self.operationQueue = NSOperationQueue()
         self.receivedString = nil
+        self.receivedDataBuffer = NSMutableData()
 
         super.init();
         self.connect()
@@ -106,17 +108,13 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
 //MARK: NSURLSessionDataDelegate
 
     public func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveData data: NSData) {
-
         if readyState != EventSourceState.Open {
             return
         }
-
-        var buffer = [UInt8](count: data.length, repeatedValue: 0)
-        data.getBytes(&buffer, length: data.length)
         
-        if let receivedString = String(bytes: buffer, encoding: NSUTF8StringEncoding) {
-            parseEventStream(receivedString)
-        }
+        self.receivedDataBuffer.appendData(data)
+        let eventStream = extractEventsFromBuffer()
+        parseEventStream(eventStream)
     }
 
     public func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveResponse response: NSURLResponse, completionHandler: ((NSURLSessionResponseDisposition) -> Void)) {
@@ -152,12 +150,37 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
 
 //MARK: Helpers
 
-    private func parseEventStream(events: String) {
+    private func extractEventsFromBuffer() -> [String] {
+        let delimiter = "\n\n".dataUsingEncoding(NSUTF8StringEncoding)!
+        var events = [String]()
+        
+        // Find first occurrence of delimiter
+        var searchRange = NSMakeRange(0, receivedDataBuffer.length)
+        var foundRange = receivedDataBuffer.rangeOfData(delimiter, options: [], range: searchRange)
+        while foundRange.location != NSNotFound {
+            // Append event
+            if foundRange.location > searchRange.location {
+                let dataChunk = receivedDataBuffer.subdataWithRange(
+                    NSMakeRange(searchRange.location, foundRange.location - searchRange.location)
+                )
+                events.append(NSString(data: dataChunk, encoding: NSUTF8StringEncoding) as! String)
+            }
+            // Search for next occurrence of delimiter
+            searchRange.location = foundRange.location + foundRange.length
+            searchRange.length = receivedDataBuffer.length - searchRange.location
+            foundRange = receivedDataBuffer.rangeOfData(delimiter, options: [], range: searchRange)
+        }
+        
+        // Remove the found events from the buffer
+        receivedDataBuffer.replaceBytesInRange(NSMakeRange(0,searchRange.location), withBytes: nil, length: 0)
+        
+        return events
+    }
+    
+    private func parseEventStream(events: [String]) {
         var parsedEvents: [(id: String?, event: String?, data: String?)] = Array()
 
-        let events = events.componentsSeparatedByString("\n\n")
-        for event in events as [String] {
-
+        for event in events {
             if event.isEmpty {
                 continue
             }
@@ -176,23 +199,20 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
             parsedEvents.append(parseEvent(event))
         }
 
-        for parsedEvent in parsedEvents as [(id: String?, event: String?, data: String?)] {
+        for parsedEvent in parsedEvents {
             self.lastEventID = parsedEvent.id
 
-            if parsedEvent.event == nil && parsedEvent.data != nil {
-                if(self.onMessageCallback != nil) {
+            if parsedEvent.event == nil {
+                if let data = parsedEvent.data, onMessage = self.onMessageCallback {
                     dispatch_async(dispatch_get_main_queue()) {
-                        self.onMessageCallback!(id:self.lastEventID,event: "message",data: parsedEvent.data)
+                        onMessage(id: self.lastEventID, event: "message", data: data)
                     }
                 }
             }
 
-            if parsedEvent.event != nil && parsedEvent.data != nil {
-                if (self.eventListeners[parsedEvent.event!] != nil) {
-                    dispatch_async(dispatch_get_main_queue()) {
-                        let eventHandler = self.eventListeners[parsedEvent.event!]
-                        eventHandler!(id:self.lastEventID,event:parsedEvent.event!, data: parsedEvent.data!)
-                    }
+            if let event = parsedEvent.event, data = parsedEvent.data, eventHandler = self.eventListeners[event] {
+                dispatch_async(dispatch_get_main_queue()) {
+                    eventHandler(id: self.lastEventID, event: event, data: data)
                 }
             }
         }

--- a/EventSourceExample/Info.plist
+++ b/EventSourceExample/Info.plist
@@ -22,6 +22,11 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/EventSourceTests/EventSourceTests.swift
+++ b/EventSourceTests/EventSourceTests.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import XCTest
+@testable import EventSource
 
 class EventSourceTests: XCTestCase {
     
@@ -78,7 +79,7 @@ class EventSourceTests: XCTestCase {
     func testAddEventListenerAndReceiveEvent() {
         let expectation = self.expectationWithDescription("onEvent should be called")
 
-        let eventListenerAndReceiveEventData = "id: event-id\nevent:event-event\ndata:event-data".dataUsingEncoding(NSUTF8StringEncoding)
+        let eventListenerAndReceiveEventData = "id: event-id\nevent:event-event\ndata:event-data\n\n".dataUsingEncoding(NSUTF8StringEncoding)
         sut!.addEventListener("event-event") { (id, event, data) in
             XCTAssertEqual(event!, "event-event", "the event should be test")
             XCTAssertEqual(id!, "event-id", "the event id should be received")
@@ -91,7 +92,7 @@ class EventSourceTests: XCTestCase {
         sut?.callDidReceiveData(eventListenerAndReceiveEventData!)
 
         self.waitForExpectationsWithTimeout(2) { (error) in
-            if let _ = error{
+            if let _ = error {
                 XCTFail("Expectation not fulfilled")
             }
         }
@@ -100,7 +101,7 @@ class EventSourceTests: XCTestCase {
     func testMultilineData() {
         let expectation = self.expectationWithDescription("onMessage should be called")
 
-        let retryEventData = "id: event-id\ndata:event-data-first\ndata:event-data-second".dataUsingEncoding(NSUTF8StringEncoding)
+        let retryEventData = "id: event-id\ndata:event-data-first\ndata:event-data-second\n\n".dataUsingEncoding(NSUTF8StringEncoding)
         sut!.onMessage { (id, event, data) in
             XCTAssertEqual(event!, "message", "the event should be message")
             XCTAssertEqual(id!, "event-id", "the event id should be received")
@@ -118,10 +119,54 @@ class EventSourceTests: XCTestCase {
             }
         }
     }
+    
+    func testEventDataIsRemovedFromBufferWhenProcessed() {
+        let expectation = self.expectationWithDescription("onMessage should be called")
+        
+        let eventData = "id: event-id\ndata:event-data\n\n".dataUsingEncoding(NSUTF8StringEncoding)
+        
+        sut!.onMessage { (id, event, data) in
+            expectation.fulfill()
+        }
+        
+        sut?.callDidReceiveResponse()
+        sut?.callDidReceiveData(eventData!)
+        self.waitForExpectationsWithTimeout(2) { (error) in
+            if let _ = error{
+                XCTFail("Expectation not fulfilled")
+            }
+        }
+        XCTAssertEqual(sut!.receivedDataBuffer.length, 0)
+    }
+    
+    func testEventDataSplitOverMultiplePackets() {
+        let expectation = self.expectationWithDescription("onMessage should be called")
+        
+        let dataPacket1 = "id: event-id\nda".dataUsingEncoding(NSUTF8StringEncoding)
+        let dataPacket2 = "ta:event-data\n\n".dataUsingEncoding(NSUTF8StringEncoding)
+        sut!.onMessage { (id, event, data) in
+            XCTAssertEqual(event!, "message", "the event should be message")
+            XCTAssertEqual(id!, "event-id", "the event id should be received")
+            XCTAssertEqual(data!, "event-data", "the event data should be received")
+            
+            expectation.fulfill()
+        }
+        
+        sut?.callDidReceiveResponse()
+        sut?.callDidReceiveData(dataPacket1!)
+        sut?.callDidReceiveData(dataPacket2!)
+        
+        self.waitForExpectationsWithTimeout(2) { (error) in
+            if let _ = error{
+                XCTFail("Expectation not fulfilled")
+            }
+        }
+    }
 
     func testCorrectlyStoringLastEventID() {
         let expectation = self.expectationWithDescription("onMessage should be called")
-        let retryEventData = "id: event-id-1\ndata:event-data-first".dataUsingEncoding(NSUTF8StringEncoding)
+        
+        let retryEventData = "id: event-id-1\ndata:event-data-first\n\n".dataUsingEncoding(NSUTF8StringEncoding)
         sut!.onMessage { (id, event, data) in
             XCTAssertEqual(id!, "event-id-1", "the event id should be received")
             expectation.fulfill()
@@ -142,7 +187,7 @@ class EventSourceTests: XCTestCase {
         self.sut!.lastEventID = "event-id-1"
         
         let expectation = self.expectationWithDescription("onMessage should be called")
-        let retryEventData = "data:event-data-first".dataUsingEncoding(NSUTF8StringEncoding)
+        let retryEventData = "data:event-data-first\n\n".dataUsingEncoding(NSUTF8StringEncoding)
         self.sut!.onMessage { (id, event, data) in
             XCTAssertEqual(id!, "event-id-1", "the event id should be received")
             expectation.fulfill()
@@ -166,7 +211,6 @@ class EventSourceTests: XCTestCase {
             expectation.fulfill()
         }
 
-//        sut!.callDidCompleteWithError("error message") it's not neccesary to call this because sut is going to try to connect and fail
         self.waitForExpectationsWithTimeout(2) { (error) in
             if let _ = error{
                 XCTFail("Expectation not fulfilled")


### PR DESCRIPTION
Added a buffer and some processing to find and extract events from the buffer each time a new packet is received.
Had to update all the tests so that the test data contained the delimiter \n\n.
