### PR TITLE
Events without values must be interpreted as having values with empty strings per spec

### DIFF
--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -254,6 +254,8 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
                     } else {
                         event[key as! String] = value! as String
                     }
+                } else if (key != nil && value == nil) {
+                    event[key as! String] = ""
                 }
             }
         }

--- a/EventSourceTests/EventSourceTests.swift
+++ b/EventSourceTests/EventSourceTests.swift
@@ -120,6 +120,27 @@ class EventSourceTests: XCTestCase {
         }
     }
     
+    func testEmptyDataValue() {
+        let expectation = self.expectationWithDescription("onMessage should be called")
+        
+        let emptyDataValueEvent = "event:done\ndata\n\n".dataUsingEncoding(NSUTF8StringEncoding)
+        sut!.addEventListener("done") { (id, event, data) in
+            XCTAssertEqual(event!, "done", "the event should be message")
+            XCTAssertEqual(data!, "", "the event data should an empty string")
+            
+            expectation.fulfill()
+        }
+        
+        sut?.callDidReceiveResponse()
+        sut?.callDidReceiveData(emptyDataValueEvent!)
+        
+        self.waitForExpectationsWithTimeout(2) { (error) in
+            if let _ = error{
+                XCTFail("Expectation not fulfilled")
+            }
+        }
+    }
+    
     func testEventDataIsRemovedFromBufferWhenProcessed() {
         let expectation = self.expectationWithDescription("onMessage should be called")
         


### PR DESCRIPTION
According to the EventSource spec (see section 7: Interpreting an event stream), a line that has a field, but no value, must be interpreted as having an empty string as a value.

> Otherwise, the string is not empty but does not contain a U+003A COLON character (:)
> Process the field using the steps described below, using the whole line as the field name, and the empty string as the field value.

Additionally, see the examples provided in the spec:

> The following stream fires two events:
> 
> data
> 
> data
> data
> 
> data:
> The first block fires events with the data set to the empty string, as would the last block if it was followed >by a blank line. The middle block fires an event with the data set to a single newline character. The last >block is discarded because it is not followed by a blank line.
