### PR TITLE
Add support for using multiple EventSource instances

### DIFF
--- a/EventSource.xcodeproj/project.pbxproj
+++ b/EventSource.xcodeproj/project.pbxproj
@@ -170,7 +170,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Inaka;
 				TargetAttributes = {
 					41DFE4231A8E686F000C3519 = {
@@ -291,6 +291,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;

--- a/EventSource.xcodeproj/project.pbxproj
+++ b/EventSource.xcodeproj/project.pbxproj
@@ -168,6 +168,8 @@
 		41DFE41C1A8E686F000C3519 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = Inaka;
 				TargetAttributes = {

--- a/EventSource.xcodeproj/project.pbxproj
+++ b/EventSource.xcodeproj/project.pbxproj
@@ -354,6 +354,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/EventSourceExample/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inaka.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -364,6 +365,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/EventSourceExample/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inaka.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -379,6 +381,7 @@
 				);
 				INFOPLIST_FILE = EventSourceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inaka.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/EventSource.app/EventSource";
 			};
@@ -391,6 +394,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = EventSourceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inaka.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/EventSource.app/EventSource";
 			};

--- a/EventSource.xcodeproj/project.pbxproj
+++ b/EventSource.xcodeproj/project.pbxproj
@@ -372,10 +372,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -391,10 +388,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = EventSourceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/EventSource.xcodeproj/xcshareddata/xcschemes/EventSource.xcscheme
+++ b/EventSource.xcodeproj/xcshareddata/xcschemes/EventSource.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -69,15 +69,18 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -93,10 +96,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -30,7 +30,8 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
     internal var task : NSURLSessionDataTask?
     private var operationQueue: NSOperationQueue
     private var errorBeforeSetErrorCallBack: NSError?
-
+    internal let receivedDataBuffer: NSMutableData
+    
     var event = Dictionary<String, String>()
 
     
@@ -41,6 +42,7 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
         self.readyState = EventSourceState.Closed
         self.operationQueue = NSOperationQueue()
         self.receivedString = nil
+        self.receivedDataBuffer = NSMutableData()
 
         super.init();
         self.connect()
@@ -106,17 +108,13 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
 //MARK: NSURLSessionDataDelegate
 
     public func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveData data: NSData) {
-
         if readyState != EventSourceState.Open {
             return
         }
-
-        var buffer = [UInt8](count: data.length, repeatedValue: 0)
-        data.getBytes(&buffer, length: data.length)
         
-        if let receivedString = String(bytes: buffer, encoding: NSUTF8StringEncoding) {
-            parseEventStream(receivedString)
-        }
+        self.receivedDataBuffer.appendData(data)
+        let eventStream = extractEventsFromBuffer()
+        parseEventStream(eventStream)
     }
 
     public func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveResponse response: NSURLResponse, completionHandler: ((NSURLSessionResponseDisposition) -> Void)) {
@@ -152,12 +150,37 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
 
 //MARK: Helpers
 
-    private func parseEventStream(events: String) {
+    private func extractEventsFromBuffer() -> [String] {
+        let delimiter = "\n\n".dataUsingEncoding(NSUTF8StringEncoding)!
+        var events = [String]()
+        
+        // Find first occurrence of delimiter
+        var searchRange = NSMakeRange(0, receivedDataBuffer.length)
+        var foundRange = receivedDataBuffer.rangeOfData(delimiter, options: [], range: searchRange)
+        while foundRange.location != NSNotFound {
+            // Append event
+            if foundRange.location > searchRange.location {
+                let dataChunk = receivedDataBuffer.subdataWithRange(
+                    NSMakeRange(searchRange.location, foundRange.location - searchRange.location)
+                )
+                events.append(NSString(data: dataChunk, encoding: NSUTF8StringEncoding) as! String)
+            }
+            // Search for next occurrence of delimiter
+            searchRange.location = foundRange.location + foundRange.length
+            searchRange.length = receivedDataBuffer.length - searchRange.location
+            foundRange = receivedDataBuffer.rangeOfData(delimiter, options: [], range: searchRange)
+        }
+        
+        // Remove the found events from the buffer
+        receivedDataBuffer.replaceBytesInRange(NSMakeRange(0,searchRange.location), withBytes: nil, length: 0)
+        
+        return events
+    }
+    
+    private func parseEventStream(events: [String]) {
         var parsedEvents: [(id: String?, event: String?, data: String?)] = Array()
 
-        let events = events.componentsSeparatedByString("\n\n")
-        for event in events as [String] {
-
+        for event in events {
             if event.isEmpty {
                 continue
             }
@@ -176,23 +199,20 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
             parsedEvents.append(parseEvent(event))
         }
 
-        for parsedEvent in parsedEvents as [(id: String?, event: String?, data: String?)] {
+        for parsedEvent in parsedEvents {
             self.lastEventID = parsedEvent.id
 
-            if parsedEvent.event == nil && parsedEvent.data != nil {
-                if(self.onMessageCallback != nil) {
+            if parsedEvent.event == nil {
+                if let data = parsedEvent.data, onMessage = self.onMessageCallback {
                     dispatch_async(dispatch_get_main_queue()) {
-                        self.onMessageCallback!(id:self.lastEventID,event: "message",data: parsedEvent.data)
+                        onMessage(id: self.lastEventID, event: "message", data: data)
                     }
                 }
             }
 
-            if parsedEvent.event != nil && parsedEvent.data != nil {
-                if (self.eventListeners[parsedEvent.event!] != nil) {
-                    dispatch_async(dispatch_get_main_queue()) {
-                        let eventHandler = self.eventListeners[parsedEvent.event!]
-                        eventHandler!(id:self.lastEventID,event:parsedEvent.event!, data: parsedEvent.data!)
-                    }
+            if let event = parsedEvent.event, data = parsedEvent.data, eventHandler = self.eventListeners[event] {
+                dispatch_async(dispatch_get_main_queue()) {
+                    eventHandler(id: self.lastEventID, event: event, data: data)
                 }
             }
         }

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -247,7 +247,7 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
         if let milli = eventString.componentsSeparatedByCharactersInSet(separators).last {
             let milliseconds = trim(milli)
 
-            if let intMiliseconds = milliseconds.toInt() {
+            if let intMiliseconds = Int(milliseconds) {
                 reconnectTime = intMiliseconds
             }
         }
@@ -261,7 +261,7 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
     class public func basicAuth(username: String, password: String) -> String {
         let authString = "\(username):\(password)"
         let authData = authString.dataUsingEncoding(NSUTF8StringEncoding)
-        let base64String = authData!.base64EncodedStringWithOptions(nil)
+        let base64String = authData!.base64EncodedStringWithOptions([])
 
         return "Basic \(base64String)"
     }

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -17,7 +17,9 @@ enum EventSourceState {
 public class EventSource: NSObject, NSURLSessionDataDelegate {
 
     let url: NSURL
+    public var usesTransientLastEventID: Bool = false;
     private let lastEventIDKey = "com.inaka.eventSource.lastEventId"
+    private var transientLastEventID: String?
     private let receivedString: NSString?
     private var onOpenCallback: (Void -> Void)?
     private var onErrorCallback: (NSError? -> Void)?
@@ -220,18 +222,27 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
 
     internal var lastEventID: String? {
         set {
-            if let lastEventID = newValue {
-                let defaults = NSUserDefaults.standardUserDefaults()
-                defaults.setObject(lastEventID, forKey: lastEventIDKey)
-                defaults.synchronize()
+            if (usesTransientLastEventID == true) {
+                self.transientLastEventID = newValue
+            } else {
+                if let lastEventID = newValue {
+                    let defaults = NSUserDefaults.standardUserDefaults()
+                    defaults.setObject(lastEventID, forKey: lastEventIDKey)
+                    defaults.synchronize()
+                }
             }
         }
 
         get {
-            let defaults = NSUserDefaults.standardUserDefaults()
+            
+            if (usesTransientLastEventID == true) {
+                return self.transientLastEventID
+            } else {
+                let defaults = NSUserDefaults.standardUserDefaults()
 
-            if let lastEventID = defaults.stringForKey(lastEventIDKey) {
-                return lastEventID
+                if let lastEventID = defaults.stringForKey(lastEventIDKey) {
+                    return lastEventID
+                }
             }
             return nil
         }

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -143,7 +143,7 @@ public class EventSource: NSObject, NSURLSessionDataDelegate {
 
         dispatch_async(dispatch_get_main_queue()) {
             if let errorCallback = self.onErrorCallback {
-                self.onErrorCallback!(error)
+                errorCallback(error)
             }else {
                 self.errorBeforeSetErrorCallBack = error
             }

--- a/EventSourceExample/Info.plist
+++ b/EventSourceExample/Info.plist
@@ -22,6 +22,11 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/EventSourceExample/Info.plist
+++ b/EventSourceExample/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.inaka.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/EventSourceExample/ViewController.swift
+++ b/EventSourceExample/ViewController.swift
@@ -76,7 +76,7 @@ class ViewController: UIViewController {
         self.squareConstraint.constant = 0
         self.view.layoutIfNeeded()
         
-        UIView.animateKeyframesWithDuration(2, delay: 0, options: UIViewKeyframeAnimationOptions.Repeat | UIViewKeyframeAnimationOptions.Autoreverse , animations: { () in
+        UIView.animateKeyframesWithDuration(2, delay: 0, options: [UIViewKeyframeAnimationOptions.Repeat, UIViewKeyframeAnimationOptions.Autoreverse] , animations: { () in
             self.squareConstraint.constant = finalPosition
             self.view.layoutIfNeeded()            
         }, completion: nil)

--- a/EventSourceExample/ViewController.swift
+++ b/EventSourceExample/ViewController.swift
@@ -56,7 +56,7 @@ class ViewController: UIViewController {
         self.idLabel.text = ""
         
         if let eventID = id {
-            self.idLabel.text = id
+            self.idLabel.text = eventID
         }
         
         if let eventName = event {

--- a/EventSourceTests/EventSourceTests.swift
+++ b/EventSourceTests/EventSourceTests.swift
@@ -47,7 +47,7 @@ class EventSourceTests: XCTestCase {
     }
 
     func testURL() {
-        XCTAssertEqual("http://127.0.0.1", sut!.url.absoluteString!, "the URL should be the same")
+        XCTAssertEqual("http://127.0.0.1", sut!.url.absoluteString, "the URL should be the same")
     }
 
     func testDefaultRetryTimeAndChangeRetryTime() {
@@ -91,7 +91,7 @@ class EventSourceTests: XCTestCase {
         sut?.callDidReceiveData(eventListenerAndReceiveEventData!)
 
         self.waitForExpectationsWithTimeout(2) { (error) in
-            if let receivedError = error{
+            if let _ = error{
                 XCTFail("Expectation not fulfilled")
             }
         }
@@ -113,7 +113,7 @@ class EventSourceTests: XCTestCase {
         sut?.callDidReceiveData(retryEventData!)
 
         self.waitForExpectationsWithTimeout(2) { (error) in
-            if let receivedError = error{
+            if let _ = error{
                 XCTFail("Expectation not fulfilled")
             }
         }
@@ -131,27 +131,31 @@ class EventSourceTests: XCTestCase {
         sut?.callDidReceiveData(retryEventData!)
 
         self.waitForExpectationsWithTimeout(2) { (error) in
-            if let receivedError = error{
+            if let _ = error {
                 XCTFail("Expectation not fulfilled")
             }
-            XCTAssertEqual((self.sut?.lastEventID)!, "event-id-1", "last event id stored is different from sent")
-
-            let expectation2 = self.expectationWithDescription("onMessage should be called")
-            let retryEventData2 = "data:event-data-first".dataUsingEncoding(NSUTF8StringEncoding)
-            self.sut!.onMessage { (id, event, data) in
-                XCTAssertEqual(id!, "event-id-1", "the event id should be received")
-                expectation2.fulfill()
+            XCTAssertEqual(self.sut!.lastEventID!, "event-id-1", "last event id stored is different from sent")
+        }
+    }
+    
+    func testLastEventIDNotUpdatedForEventWithNoID() {
+        self.sut!.lastEventID = "event-id-1"
+        
+        let expectation = self.expectationWithDescription("onMessage should be called")
+        let retryEventData = "data:event-data-first".dataUsingEncoding(NSUTF8StringEncoding)
+        self.sut!.onMessage { (id, event, data) in
+            XCTAssertEqual(id!, "event-id-1", "the event id should be received")
+            expectation.fulfill()
+        }
+        
+        self.sut?.callDidReceiveResponse()
+        self.sut?.callDidReceiveData(retryEventData!)
+        
+        self.waitForExpectationsWithTimeout(2) { (error) in
+            if let _ = error {
+                XCTFail("Expectation not fulfilled")
             }
-
-            self.sut?.callDidReceiveResponse()
-            self.sut?.callDidReceiveData(retryEventData2!)
-
-            self.waitForExpectationsWithTimeout(2) { (error) in
-                if let receivedError = error{
-                    XCTFail("Expectation not fulfilled")
-                }
-                XCTAssertEqual((self.sut?.lastEventID)!, "event-id-1", "last event id stored is different from sent")
-            }
+            XCTAssertEqual(self.sut!.lastEventID!, "event-id-1", "last event id stored is different from sent")
         }
     }
 
@@ -164,7 +168,7 @@ class EventSourceTests: XCTestCase {
 
 //        sut!.callDidCompleteWithError("error message") it's not neccesary to call this because sut is going to try to connect and fail
         self.waitForExpectationsWithTimeout(2) { (error) in
-            if let receivedError = error{
+            if let _ = error{
                 XCTFail("Expectation not fulfilled")
             }
         }
@@ -179,7 +183,7 @@ class EventSourceTests: XCTestCase {
 
         sut!.callDidReceiveResponse()
         self.waitForExpectationsWithTimeout(2) { (error) in
-            if let receivedError = error{
+            if let _ = error{
                 XCTFail("Expectation not fulfilled")
             }
         }

--- a/EventSourceTests/EventSourceTests.swift
+++ b/EventSourceTests/EventSourceTests.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import XCTest
+@testable import EventSource
 
 class EventSourceTests: XCTestCase {
     
@@ -78,7 +79,7 @@ class EventSourceTests: XCTestCase {
     func testAddEventListenerAndReceiveEvent() {
         let expectation = self.expectationWithDescription("onEvent should be called")
 
-        let eventListenerAndReceiveEventData = "id: event-id\nevent:event-event\ndata:event-data".dataUsingEncoding(NSUTF8StringEncoding)
+        let eventListenerAndReceiveEventData = "id: event-id\nevent:event-event\ndata:event-data\n\n".dataUsingEncoding(NSUTF8StringEncoding)
         sut!.addEventListener("event-event") { (id, event, data) in
             XCTAssertEqual(event!, "event-event", "the event should be test")
             XCTAssertEqual(id!, "event-id", "the event id should be received")
@@ -91,7 +92,7 @@ class EventSourceTests: XCTestCase {
         sut?.callDidReceiveData(eventListenerAndReceiveEventData!)
 
         self.waitForExpectationsWithTimeout(2) { (error) in
-            if let _ = error{
+            if let _ = error {
                 XCTFail("Expectation not fulfilled")
             }
         }
@@ -100,7 +101,7 @@ class EventSourceTests: XCTestCase {
     func testMultilineData() {
         let expectation = self.expectationWithDescription("onMessage should be called")
 
-        let retryEventData = "id: event-id\ndata:event-data-first\ndata:event-data-second".dataUsingEncoding(NSUTF8StringEncoding)
+        let retryEventData = "id: event-id\ndata:event-data-first\ndata:event-data-second\n\n".dataUsingEncoding(NSUTF8StringEncoding)
         sut!.onMessage { (id, event, data) in
             XCTAssertEqual(event!, "message", "the event should be message")
             XCTAssertEqual(id!, "event-id", "the event id should be received")
@@ -118,10 +119,54 @@ class EventSourceTests: XCTestCase {
             }
         }
     }
+    
+    func testEventDataIsRemovedFromBufferWhenProcessed() {
+        let expectation = self.expectationWithDescription("onMessage should be called")
+        
+        let eventData = "id: event-id\ndata:event-data\n\n".dataUsingEncoding(NSUTF8StringEncoding)
+        
+        sut!.onMessage { (id, event, data) in
+            expectation.fulfill()
+        }
+        
+        sut?.callDidReceiveResponse()
+        sut?.callDidReceiveData(eventData!)
+        self.waitForExpectationsWithTimeout(2) { (error) in
+            if let _ = error{
+                XCTFail("Expectation not fulfilled")
+            }
+        }
+        XCTAssertEqual(sut!.receivedDataBuffer.length, 0)
+    }
+    
+    func testEventDataSplitOverMultiplePackets() {
+        let expectation = self.expectationWithDescription("onMessage should be called")
+        
+        let dataPacket1 = "id: event-id\nda".dataUsingEncoding(NSUTF8StringEncoding)
+        let dataPacket2 = "ta:event-data\n\n".dataUsingEncoding(NSUTF8StringEncoding)
+        sut!.onMessage { (id, event, data) in
+            XCTAssertEqual(event!, "message", "the event should be message")
+            XCTAssertEqual(id!, "event-id", "the event id should be received")
+            XCTAssertEqual(data!, "event-data", "the event data should be received")
+            
+            expectation.fulfill()
+        }
+        
+        sut?.callDidReceiveResponse()
+        sut?.callDidReceiveData(dataPacket1!)
+        sut?.callDidReceiveData(dataPacket2!)
+        
+        self.waitForExpectationsWithTimeout(2) { (error) in
+            if let _ = error{
+                XCTFail("Expectation not fulfilled")
+            }
+        }
+    }
 
     func testCorrectlyStoringLastEventID() {
         let expectation = self.expectationWithDescription("onMessage should be called")
-        let retryEventData = "id: event-id-1\ndata:event-data-first".dataUsingEncoding(NSUTF8StringEncoding)
+        
+        let retryEventData = "id: event-id-1\ndata:event-data-first\n\n".dataUsingEncoding(NSUTF8StringEncoding)
         sut!.onMessage { (id, event, data) in
             XCTAssertEqual(id!, "event-id-1", "the event id should be received")
             expectation.fulfill()
@@ -142,7 +187,7 @@ class EventSourceTests: XCTestCase {
         self.sut!.lastEventID = "event-id-1"
         
         let expectation = self.expectationWithDescription("onMessage should be called")
-        let retryEventData = "data:event-data-first".dataUsingEncoding(NSUTF8StringEncoding)
+        let retryEventData = "data:event-data-first\n\n".dataUsingEncoding(NSUTF8StringEncoding)
         self.sut!.onMessage { (id, event, data) in
             XCTAssertEqual(id!, "event-id-1", "the event id should be received")
             expectation.fulfill()
@@ -166,7 +211,6 @@ class EventSourceTests: XCTestCase {
             expectation.fulfill()
         }
 
-//        sut!.callDidCompleteWithError("error message") it's not neccesary to call this because sut is going to try to connect and fail
         self.waitForExpectationsWithTimeout(2) { (error) in
             if let _ = error{
                 XCTFail("Expectation not fulfilled")

--- a/EventSourceTests/Info.plist
+++ b/EventSourceTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.inaka.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
lastEventID is being persisted to user defaults, which means that any application wishing to connect to two or more EventSources would have conflicting last event IDs. By adding an option to keep the last event IDs in memory and not persist to defaults, you can use multiple throw away event sources in an application.

Added a test case covering using two EventSources, one persisting lastEventID, and the other keeping it in memory.
