### PR TITLE
Added possibility to close the connection on other http response codes

### DIFF
--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -34,11 +34,12 @@ open class EventSource: NSObject, URLSessionDataDelegate {
     internal let receivedDataBuffer: NSMutableData
 	fileprivate let uniqueIdentifier: String
     fileprivate let validNewlineCharacters = ["\r\n", "\n", "\r"]
+    fileprivate let closeCodes: [Int]
 
     var event = Dictionary<String, String>()
 
 
-    public init(url: String, headers: [String : String] = [:]) {
+    public init(url: String, headers: [String : String] = [:], closeCodes: [Int] = [204]) {
 
         self.url = URL(string: url)!
         self.headers = headers
@@ -46,7 +47,7 @@ open class EventSource: NSObject, URLSessionDataDelegate {
         self.operationQueue = OperationQueue()
         self.receivedString = nil
         self.receivedDataBuffer = NSMutableData()
-
+        self.closeCodes = closeCodes
 
         var port = ""
         if let optionalPort = self.url.port {
@@ -107,7 +108,7 @@ open class EventSource: NSObject, URLSessionDataDelegate {
 			return false
 		}
 
-		if response.statusCode == 204 {
+        if closeCodes.contains(response.statusCode) {
 			self.close()
 			return true
 		}

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Thanks to all the contributors for pointing out missing stuff or problems and fi
 - [col](https://github.com/col)
 - [heyzooi](https://github.com/heyzooi)
 - [alexpalman](https://github.com/alexpalman)
+- [aenglund](https://github.com/aenglund)
 
 ### Contact Us
 For **questions** or **general comments** regarding the use of this library, please use our public


### PR DESCRIPTION
I have a use case where I need to close the connection in case of 401 Unauthorized. However, I couldn't find a good way to solve that with the current solution.
Maybe this could be a good way to add that functionality?
