### PR TITLE
Fix unwanted omitting events right after commented lines

### DIFF
--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -245,11 +245,11 @@ open class EventSource: NSObject, URLSessionDataDelegate {
         var parsedEvents: [(id: String?, event: String?, data: String?)] = Array()
 
         for event in events {
-            if event.isEmpty {
-                continue
-            }
+            let event = event.components(separatedBy: "\n")
+                .filter {!$0.hasPrefix(":")} // remove comment lines
+                .joined(separator: "\n")
 
-            if event.hasPrefix(":") {
+            if event.isEmpty {
                 continue
             }
 


### PR DESCRIPTION
I work with [tootsuite/mastodon] streaming API.
Sometimes IKEventSource ignores events.
The case is where an event is placed right after `:thump\n` (commented line). for example this event will be ignored in parsing events:

```
:thump
event: update
data: {"id": ... }
```

This PR removes these comment lines before parsing event structures.