### PR TITLE
Fix infinite retry for 404 status code

### DIFF
--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -12,6 +12,7 @@ public enum EventSourceState {
     case connecting
     case open
     case closed
+    case invalidated
 }
 
 open class EventSource: NSObject, URLSessionDataDelegate {
@@ -65,6 +66,8 @@ open class EventSource: NSObject, URLSessionDataDelegate {
 //Mark: Connect
 
     func connect() {
+        guard self.readyState != .invalidated else { return }
+
         var additionalHeaders = self.headers
         if let eventID = self.lastEventID {
             additionalHeaders["Last-Event-Id"] = eventID
@@ -113,6 +116,13 @@ open class EventSource: NSObject, URLSessionDataDelegate {
 		}
 		return false
 	}
+
+//Mark: Invalidate
+
+    open func invalidate() {
+        self.readyState = EventSourceState.invalidated
+        self.urlSession?.invalidateAndCancel()
+    }
 
 //Mark: EventListeners
 


### PR DESCRIPTION
For endpoint that returns 404, EventSource attempt to re-connect by `DispatchQueue.after` infinitely.
There seem to be no way to terminate at EventSource user side.

This PR is workaround for the problem, with the EventSource user calling `invalidate()` to refuse `connect()` by the retry.