### PR TITLE
Fix issue with strong reference making library contain itself

### DIFF
--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -72,8 +72,8 @@ open class EventSource: NSObject, URLSessionDataDelegate {
         additionalHeaders["Cache-Control"] = "no-cache"
 
         let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = TimeInterval(INT_MAX)
-        configuration.timeoutIntervalForResource = TimeInterval(INT_MAX)
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 30
         configuration.httpAdditionalHeaders = additionalHeaders
 
         self.readyState = EventSourceState.connecting

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -192,9 +192,9 @@ open class EventSource: NSObject, URLSessionDataDelegate {
         if error == nil || (error! as NSError).code != -999 {
             let nanoseconds = Double(self.retryTime) / 1000.0 * Double(NSEC_PER_SEC)
             let delayTime = DispatchTime.now() + Double(Int64(nanoseconds)) / Double(NSEC_PER_SEC)
-            DispatchQueue.main.asyncAfter(deadline: delayTime) { [weak self] in
-                if isAborted == false {
-                    self?.connect()
+            DispatchQueue.main.asyncAfter(deadline: delayTime) {
+                if self.isAborted == false {
+                    self.connect()
                 }
             }
         }

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -183,8 +183,8 @@ open class EventSource: NSObject, URLSessionDataDelegate {
         if error == nil || (error! as NSError).code != -999 {
             let nanoseconds = Double(self.retryTime) / 1000.0 * Double(NSEC_PER_SEC)
             let delayTime = DispatchTime.now() + Double(Int64(nanoseconds)) / Double(NSEC_PER_SEC)
-            DispatchQueue.main.asyncAfter(deadline: delayTime) {
-                self.connect()
+            DispatchQueue.main.asyncAfter(deadline: delayTime) { [weak self] in
+                self?.connect()
             }
         }
 

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -72,8 +72,8 @@ open class EventSource: NSObject, URLSessionDataDelegate {
         additionalHeaders["Cache-Control"] = "no-cache"
 
         let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = 30
-        configuration.timeoutIntervalForResource = 30
+        configuration.timeoutIntervalForRequest = TimeInterval(INT_MAX)
+        configuration.timeoutIntervalForResource = TimeInterval(INT_MAX)
         configuration.httpAdditionalHeaders = additionalHeaders
 
         self.readyState = EventSourceState.connecting

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -35,6 +35,7 @@ open class EventSource: NSObject, URLSessionDataDelegate {
 	fileprivate let uniqueIdentifier: String
     fileprivate let validNewlineCharacters = ["\r\n", "\n", "\r"]
 
+    fileprivate var isAborted = false
     var event = Dictionary<String, String>()
 
 
@@ -97,6 +98,14 @@ open class EventSource: NSObject, URLSessionDataDelegate {
     open func close() {
         self.readyState = EventSourceState.closed
         self.urlSession?.invalidateAndCancel()
+    }
+    
+    open func abort() {
+        
+        self.readyState = EventSourceState.closed
+        self.urlSession?.invalidateAndCancel()
+        isAborted = true
+        
     }
 
 	fileprivate func receivedMessageToClose(_ httpResponse: HTTPURLResponse?) -> Bool {
@@ -184,7 +193,9 @@ open class EventSource: NSObject, URLSessionDataDelegate {
             let nanoseconds = Double(self.retryTime) / 1000.0 * Double(NSEC_PER_SEC)
             let delayTime = DispatchTime.now() + Double(Int64(nanoseconds)) / Double(NSEC_PER_SEC)
             DispatchQueue.main.asyncAfter(deadline: delayTime) { [weak self] in
-                self?.connect()
+                if isAborted == false {
+                    self?.connect()
+                }
             }
         }
 


### PR DESCRIPTION
EventSource should not reconnect if another app has set its reference to nil.

var eventSource = EventSource()

// do connect
eventSource.close()
eventSource = nil 
// EventSource will still reconnect after this, if it is timed after it has started doing the async after

This pull request fixes that issue