### PR TITLE
Update `readyState` on `urlSession` error

### DIFF
--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -170,7 +170,7 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
     open func urlSession(_ session: URLSession,
                          task: URLSessionTask,
                          didCompleteWithError error: Error?) {
-
+        readyState = .closed
         guard let responseStatusCode = (task.response as? HTTPURLResponse)?.statusCode else {
             mainQueue.async { [weak self] in self?.onComplete?(nil, nil, error as NSError?) }
             return

--- a/EventSourceTests/EventSourceTests.swift
+++ b/EventSourceTests/EventSourceTests.swift
@@ -88,6 +88,7 @@ class EventSourceTests: XCTestCase {
     func testOnCompleteRetryTrue() {
         let expectation = XCTestExpectation(description: "onComplete gets called")
         eventSource.onComplete { statusCode, retry, _ in
+            XCTAssertEqual(self.eventSource.readyState, .closed)
             XCTAssertEqual(statusCode, 200)
             XCTAssertEqual(retry, false)
             expectation.fulfill()
@@ -103,6 +104,7 @@ class EventSourceTests: XCTestCase {
     func testOnCompleteRetryFalse() {
         let expectation = XCTestExpectation(description: "onComplete gets called")
         eventSource.onComplete { statusCode, retry, _ in
+            XCTAssertEqual(self.eventSource.readyState, .closed)
             XCTAssertEqual(statusCode, 250)
             XCTAssertEqual(retry, true)
             expectation.fulfill()
@@ -118,6 +120,7 @@ class EventSourceTests: XCTestCase {
     func testOnCompleteError() {
         let expectation = XCTestExpectation(description: "onComplete gets called")
         eventSource.onComplete { statusCode, retry, error in
+            XCTAssertEqual(self.eventSource.readyState, .closed)
             XCTAssertNotNil(error)
             XCTAssertNil(retry)
             XCTAssertNil(statusCode)

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "EventSource",
 	platforms: [
-		.iOS("8.0"),
+		.iOS("9.0"),
 		.macOS("10.10"),
 	],
     products: [


### PR DESCRIPTION
This PRs contains:
- Update `readyState` to `closed` when receiving an error from `URLSession`(resolves #142 )
- Updating tests to confirm that change

I also bumped iOS min version for SPM to 9.0 to avoid the following Xcode warning even if it's not related to the main issue:

```
The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.1.99.
```