### PR TITLE
Fixed assignment of retryTime from events.

### DIFF
--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -223,7 +223,10 @@ private extension EventSource {
 
         for event in events {
             lastEventId = event.id
-            retryTime = event.retryTime ?? EventSource.DefaultRetryTime
+            
+            if let eventRetryTime = event.retryTime {
+                retryTime = eventRetryTime
+            }
 
             if event.onlyRetryEvent == true {
                 continue


### PR DESCRIPTION
Previously every new event without retryTime overwrote the Source's retryTime to a default value.
Now only events with specified retryTime values are counted.