### PR TITLE
Passing error when URLSession task completes

### DIFF
--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -177,7 +177,7 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
         }
 
         let reconnect = shouldReconnect(statusCode: responseStatusCode)
-        mainQueue.async { [weak self] in self?.onComplete?(responseStatusCode, reconnect, nil) }
+        mainQueue.async { [weak self] in self?.onComplete?(responseStatusCode, reconnect, error as NSError?) }
     }
 
     open func urlSession(_ session: URLSession,


### PR DESCRIPTION
To perform reconnection when [network connection lost](https://developer.apple.com/documentation/foundation/urlerror/2293759-networkconnectionlost) we need to check the error code in `onComplete` closure. Unfortunately the URLSession task completes with response, therefore, error is not passed to the closure.